### PR TITLE
Automatic version bumping

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,22 +61,48 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
-
-task releaseClean {
+task ensureCleanRepo {
     doLast {
         if (!grgit.repository.jgit.status().call().clean) {
-            throw new GradleException('Git status is not clean, please commit or stash your changes!')
+            throw new GradleException('Git status is not clean, please stash your changes!')
         }
+    }
+}
+task releaseClean(dependsOn: ensureCleanRepo) {
+    doLast {
+        def Clean = true
+        String headCommitMessage = grgit.head().shortMessage
+        while (headCommitMessage.contains("[gradle-release-task]")) {
+            Clean = false
+            println "Found git commit: $headCommitMessage"
+            if (headCommitMessage.indexOf("vitabu-") > -1) {
+                def tagName = headCommitMessage.split("vitabu-")[1]
+                println "Removing the git tag: $tagName"
+                try {
+                    grgit.tag.remove {
+                        names = [tagName]
+                    }
+                } catch (Exception e) {
+                    println "Error while removing git tag:\n $e"
+                }
+            }
+            println "Resetting the git commit permanently!"
+            grgit.reset(commit: "HEAD~1", mode: "hard")
+            headCommitMessage = grgit.head().shortMessage
+
+        }
+        if (Clean){
+            println "Repository is already clean"
+        }
+        println "Done!"
     }
 }
 
 // Task parameters:
 //    bumpVersion -> if available will specify new versionName directly and ignores the `bumpType` parameter.
 //    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
-task releasePrepare(dependsOn: releaseClean) {
+task releasePrepare(dependsOn: ensureCleanRepo) {
     doLast {
-        def headCommit = grgit.repository.jgit.reflog().call().iterator().next().newId.name
-
         def versionName = android.defaultConfig.versionName
 
         if (versionName.indexOf("-") > -1) {
@@ -95,8 +121,6 @@ task releasePrepare(dependsOn: releaseClean) {
                 message = "Release of $versionName"
             }
         } catch (Exception e) {
-            print "Failed, undoing last changes to the repo..."
-            grgit.reset(commit: headCommit, mode: "mixed")
             throw new GradleException("Failed to tag the repo, error:\n $e")
         }
 
@@ -105,7 +129,7 @@ task releasePrepare(dependsOn: releaseClean) {
         def newVersionName
         if (project.properties.containsKey("bumpVersion")) {
             newVersionName = project.properties["bumpVersion"]
-            print "Bumping the version directly (bumpVersion=$newVersionName)"
+            println "Bumping the version directly (bumpVersion=$newVersionName)"
         } else if (project.properties.containsKey("bumpType")) {
             def (major, minor, patch) = versionName.tokenize('.')
             switch (bumpType) {
@@ -137,12 +161,24 @@ task releasePrepare(dependsOn: releaseClean) {
         buildFile.setText(buildText) //replace the build file's text
         grgit.add(patterns: ['app/build.gradle'])
         grgit.commit(message: "[gradle-release-task] prepare for next development iteration")
+        println "Done!"
     }
 
 }
 
-task performRelease(dependsOn: releaseClean) {
+task releasePerform(dependsOn: ensureCleanRepo) {
     doLast {
-        grgit.push()
+        boolean force = false
+        if (project.properties.containsKey("force")) {
+            force = project.properties["force"]
+        }
+        println "Pushing the newest commits to the remote repository (force: $force)"
+        try {
+            grgit.push(force: force)
+        } catch (Exception e) {
+            throw new GradleException("Failed to push to the repo,\n" +
+                    " you can try using -Pforce=true parameter to force the push, error: \n$e")
+        }
+        println "Done!"
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,13 +70,15 @@ task ensureCleanRepo {
 }
 task releaseClean(dependsOn: ensureCleanRepo) {
     doLast {
-        def Clean = true
+        def clean = true
+        def applicationId = android.defaultConfig.applicationId
+
         String headCommitMessage = grgit.head().shortMessage
         while (headCommitMessage.contains("[gradle-release-task]")) {
-            Clean = false
+            clean = false
             println "Found git commit: $headCommitMessage"
-            if (headCommitMessage.indexOf("vitabu-") > -1) {
-                def tagName = headCommitMessage.split("vitabu-")[1]
+            if (headCommitMessage.indexOf("$applicationId-") > -1) {
+                def tagName = headCommitMessage.split("$applicationId-")[1]
                 println "Removing the git tag: $tagName"
                 try {
                     grgit.tag.remove {
@@ -91,7 +93,7 @@ task releaseClean(dependsOn: ensureCleanRepo) {
             headCommitMessage = grgit.head().shortMessage
 
         }
-        if (Clean){
+        if (clean){
             println "Repository is already clean"
         }
         println "Done!"
@@ -103,6 +105,7 @@ task releaseClean(dependsOn: ensureCleanRepo) {
 //    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
 task releasePrepare(dependsOn: ensureCleanRepo) {
     doLast {
+        def applicationId = android.defaultConfig.applicationId
         def versionName = android.defaultConfig.versionName
 
         if (versionName.indexOf("-") > -1) {
@@ -114,7 +117,7 @@ task releasePrepare(dependsOn: ensureCleanRepo) {
         buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$versionName'")
         buildFile.setText(buildText) //replace the build file's text
         grgit.add(patterns: ['app/build.gradle'])
-        grgit.commit(message: "[gradle-release-task] prepare release vitabu-$versionName")
+        grgit.commit(message: "[gradle-release-task] prepare release $applicationId-$versionName")
         try {
             grgit.tag.add {
                 name = versionName

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.application'
-
+apply plugin: 'org.ajoberstar.grgit'
 android {
     compileSdkVersion 32
 
@@ -59,4 +59,75 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+}
+
+task releaseClean {
+    if(grgit.repository.jgit.status().paths != null){
+        throw new GradleException('Git status is not clean')
+    }
+}
+
+// Task parameters:
+//    version -> if available will specify new versionName directly and ignores the `type` parameter.
+//    type[major|minor|patch] -> will specify how the version bumping occurs.
+task releasePrepare(dependsOn: releaseClean) {
+    doLast {
+        def versionCode = android.defaultConfig.versionCode
+        def versionName = android.defaultConfig.versionName
+
+        if (versionName.indexOf("-") > -1) {
+            versionName = versionName.split("-")[0]
+        }
+
+        // Set new version name from input parameters.
+        def newVersionName
+        if (project.properties.containsKey("version")){
+            newVersionName = project.properties["version"]
+        }else {
+            def (major, minor, patch) = versionName.tokenize('.')
+            switch (type) {
+                case "major":
+                    major = major.toInteger() + 1
+                    minor = 0
+                    patch = 0
+                    break
+                case "minor":
+                    minor = minor.toInteger() + 1
+                    break
+                case "patch":
+                    patch = patch.toInteger() + 1
+                    break
+            }
+            newVersionName = "$major.$minor.$patch"
+        }
+
+        def newVersionCode = versionCode + 1
+        println "Bumping versionName from $versionName to $newVersionName"
+        println "Bumping versionCode from $versionCode to $newVersionCode"
+
+        // Prepare the release commit with the specific tag.
+        String buildText = buildFile.getText()
+        buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName'")
+        buildText = buildText.replaceFirst(/versionCode(\s+.*)/, "versionCode $newVersionCode")
+        buildFile.setText(buildText) //replace the build file's text
+        grgit.add(patterns: ['app/build.gradle'])
+        grgit.commit(message: "[gradle-release-task] prepare release vitabu-$newVersionName")
+        grgit.tag.add {
+            name = newVersionName
+            message = "Release of $newVersionName"
+        }
+
+        // Prepare for next development iteration.
+        buildText = buildFile.getText()
+        buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName-SNAPSHOT'")
+        buildFile.setText(buildText) //replace the build file's text
+        grgit.add(patterns: ['app/build.gradle'])
+        grgit.commit(message: "[gradle-release-task] prepare for next development iteration")
+    }
+}
+
+task performRelease(dependsOn: releaseClean) {
+    doLast {
+        grgit.push()
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,33 +62,51 @@ dependencies {
 }
 
 
-
 task releaseClean {
     doLast {
-//        if (!grgit.repository.jgit.status().call().clean) {
-//            throw new GradleException('Git status is not clean, please commit or stash your changes!')
-//        }
+        if (!grgit.repository.jgit.status().call().clean) {
+            throw new GradleException('Git status is not clean, please commit or stash your changes!')
+        }
     }
 }
 
 // Task parameters:
-//    version -> if available will specify new versionName directly and ignores the `type` parameter.
-//    type[major|minor|patch] -> will specify how the version bumping occurs.
+//    bumpVersion -> if available will specify new versionName directly and ignores the `bumpType` parameter.
+//    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
 task releasePrepare(dependsOn: releaseClean) {
     doLast {
-        def versionCode = android.defaultConfig.versionCode
+        def headCommit = grgit.repository.jgit.reflog().call().iterator().next().newId.name
+
         def versionName = android.defaultConfig.versionName
 
         if (versionName.indexOf("-") > -1) {
             versionName = versionName.split("-")[0]
         }
 
+        // Prepare the release commit with the specific tag.
+        String buildText = buildFile.getText()
+        buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$versionName'")
+        buildFile.setText(buildText) //replace the build file's text
+        grgit.add(patterns: ['app/build.gradle'])
+        grgit.commit(message: "[gradle-release-task] prepare release vitabu-$versionName")
+        try {
+            grgit.tag.add {
+                name = versionName
+                message = "Release of $versionName"
+            }
+        } catch (Exception e) {
+            print "Failed, undoing last changes to the repo..."
+            grgit.reset(commit: headCommit, mode: "mixed")
+            throw new GradleException("Failed to tag the repo, error:\n $e")
+        }
+
+
         // Set new version name from input parameters.
         def newVersionName
-        print project.properties.containsKey("bumpVersion")
-        if (project.properties.containsKey("bumpVersion")){
+        if (project.properties.containsKey("bumpVersion")) {
             newVersionName = project.properties["bumpVersion"]
-        }else if (project.properties.containsKey("bumpType")) {
+            print "Bumping the version directly (bumpVersion=$newVersionName)"
+        } else if (project.properties.containsKey("bumpType")) {
             def (major, minor, patch) = versionName.tokenize('.')
             switch (bumpType) {
                 case "major":
@@ -104,33 +122,23 @@ task releasePrepare(dependsOn: releaseClean) {
                     break
             }
             newVersionName = "$major.$minor.$patch"
-        }else{
+        } else {
             throw new GradleException('Either bumpType or bumpVersion parameters should be provided')
         }
 
+        // Prepare for next development iteration.
+        def versionCode = android.defaultConfig.versionCode
         def newVersionCode = versionCode + 1
         println "Bumping versionName from $versionName to $newVersionName"
         println "Bumping versionCode from $versionCode to $newVersionCode"
-
-        // Prepare the release commit with the specific tag.
-        String buildText = buildFile.getText()
-        buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName'")
-        buildText = buildText.replaceFirst(/versionCode(\s+.*)/, "versionCode $newVersionCode")
-        buildFile.setText(buildText) //replace the build file's text
-        grgit.add(patterns: ['app/build.gradle'])
-        grgit.commit(message: "[gradle-release-task] prepare release vitabu-$newVersionName")
-        grgit.tag.add {
-            name = newVersionName
-            message = "Release of $newVersionName"
-        }
-
-        // Prepare for next development iteration.
         buildText = buildFile.getText()
         buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName-SNAPSHOT'")
+        buildText = buildText.replaceFirst(/versionCode(\s+.*)/, "versionCode $newVersionCode")
         buildFile.setText(buildText) //replace the build file's text
         grgit.add(patterns: ['app/build.gradle'])
         grgit.commit(message: "[gradle-release-task] prepare for next development iteration")
     }
+
 }
 
 task performRelease(dependsOn: releaseClean) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,7 +174,7 @@ task releasePerform(dependsOn: ensureCleanRepo) {
         }
         println "Pushing the newest commits to the remote repository (force: $force)"
         try {
-            grgit.push(force: force)
+            grgit.push(force: force, tags: true)
         } catch (Exception e) {
             throw new GradleException("Failed to push to the repo,\n" +
                     " you can try using -Pforce=true parameter to force the push, error: \n$e")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,9 +65,9 @@ dependencies {
 
 task releaseClean {
     doLast {
-        if (!grgit.repository.jgit.status().call().clean) {
-            throw new GradleException('Git status is not clean')
-        }
+//        if (!grgit.repository.jgit.status().call().clean) {
+//            throw new GradleException('Git status is not clean, please commit or stash your changes!')
+//        }
     }
 }
 
@@ -85,11 +85,12 @@ task releasePrepare(dependsOn: releaseClean) {
 
         // Set new version name from input parameters.
         def newVersionName
-        if (project.properties.containsKey("version")){
-            newVersionName = project.properties["version"]
-        }else {
+        print project.properties.containsKey("bumpVersion")
+        if (project.properties.containsKey("bumpVersion")){
+            newVersionName = project.properties["bumpVersion"]
+        }else if (project.properties.containsKey("bumpType")) {
             def (major, minor, patch) = versionName.tokenize('.')
-            switch (type) {
+            switch (bumpType) {
                 case "major":
                     major = major.toInteger() + 1
                     minor = 0
@@ -103,6 +104,8 @@ task releasePrepare(dependsOn: releaseClean) {
                     break
             }
             newVersionName = "$major.$minor.$patch"
+        }else{
+            throw new GradleException('Either bumpType or bumpVersion parameters should be provided')
         }
 
         def newVersionCode = versionCode + 1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,9 +61,13 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
+
+
 task releaseClean {
-    if(grgit.repository.jgit.status().paths != null){
-        throw new GradleException('Git status is not clean')
+    doLast {
+        if (!grgit.repository.jgit.status().call().clean) {
+            throw new GradleException('Git status is not clean')
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,12 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.2'
-        classpath 'org.ajoberstar:gradle-git:+'
+        classpath 'org.ajoberstar.grgit:grgit-gradle:5.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.2'
-        
+        classpath 'org.ajoberstar:gradle-git:+'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -26,3 +26,4 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+


### PR DESCRIPTION
### Description
closes #94 
### Tasks
1. Ensure clean repo and bumping a release (using either type or version parameters) and commit the changes and prepare for the next development cycle:
```
$ ./gradlew releasePrepare [-PbumpType=(major|minor|patch)] [-PbumpVersion=x.y.z]
```
2. Push the changes to git using the Gradle-git plugin:
```
$ ./gradlew releasePerform
```