### PR TITLE
fix: could not find flexbox error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'com.google.android:flexbox:2.0.1'
+    implementation 'com.google.android.flexbox:flexbox:3.0.0'
 
     testImplementation 'junit:junit:4.13.2'
 


### PR DESCRIPTION
Fix for error during `./gradlew clean build`:

```
Could not find com.google.android:flexbox:2.0.1.
```

https://github.com/elimu-ai/vitabu/actions/runs/10296630091/job/28498292171

Documentation: https://github.com/google/flexbox-layout?tab=readme-ov-file#installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the flexbox library to version 3.0.0, enhancing layout capabilities and potentially improving performance and compatibility within the app.
  
- **Bug Fixes**
	- The library update may include various bug fixes from the previous version, contributing to a more stable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->