### PR TITLE
Release MediaPlayer when ChapterFragment is destroyed to avoid memory leaks

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
@@ -233,6 +233,11 @@ open class ChapterFragment : Fragment(), AudioListener {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        mediaPlayer?.release()
+    }
+
     open fun getUtteranceProgressListener(audioListener: AudioListener?): UtteranceProgressListener? {
         val wordPosition = intArrayOf(-1)
 


### PR DESCRIPTION
### Issue Number
* Resolves #123 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced resource cleanup during the chapter view exit to prevent potential performance and stability issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->