### PR TITLE
fix: enable tts on color os

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
 
     <queries>
         <provider android:authorities="${contentProviderApplicationId}.provider.storybook_provider" />
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
     </queries>
 
     <application


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #136

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* Enable the elimu.ai software to run on ColorOS (Oppo devices).

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
**Before**:

https://github.com/user-attachments/assets/9841520d-48a6-42e0-a0ac-4ab4e1a720f7

**After**:


https://github.com/user-attachments/assets/83e08eb6-b2f3-4f72-9964-368a795ac44f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled querying for Android's Text-to-Speech service, allowing the app to interact with TTS functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->