### PR TITLE
issue 148: Switch FAB button's icon while Text-to-Speech is playing

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
@@ -43,6 +43,9 @@ open class ChapterFragment : Fragment(), AudioListener {
 
     private var tts: TextToSpeech? = null
 
+    private var fab: FloatingActionButton ?=null
+
+
     @JvmField
     protected var readingLevelPosition: Int = 0
 
@@ -74,7 +77,7 @@ open class ChapterFragment : Fragment(), AudioListener {
 
         val root = inflater.inflate(rootLayout, container, false)
 
-        val fab = root.findViewById<FloatingActionButton>(R.id.fab)
+        fab = root.findViewById<FloatingActionButton>(R.id.fab)
         chapterRecyclerView = root.findViewById(R.id.chapter_text)
 
         // Set chapter image
@@ -154,7 +157,7 @@ open class ChapterFragment : Fragment(), AudioListener {
                 wordViewAdapter.addParagraph(Arrays.asList(*wordsInOriginalText), wordGsons)
             }
         } else {
-            fab.visibility = View.GONE
+            fab!!.visibility = View.GONE
         }
 
         return root
@@ -169,7 +172,6 @@ open class ChapterFragment : Fragment(), AudioListener {
         fab.setOnClickListener(object : View.OnClickListener {
             override fun onClick(view: View) {
                 Log.i(javaClass.name, "onClick")
-                playAudio(chapterText, this@ChapterFragment)
             }
         })
     }
@@ -187,7 +189,10 @@ open class ChapterFragment : Fragment(), AudioListener {
                 null,
                 "0"
             )
+
             tts!!.playSilentUtterance(PARAGRAPH_PAUSE, TextToSpeech.QUEUE_ADD, null)
+            if (tts!!.isSpeaking==true)fab!!.setImageResource(R.drawable.ic_hearing)
+            else fab!!.setImageResource(R.drawable.baseline_pause_24)
         }
     }
 

--- a/app/src/main/res/drawable/baseline_pause_24.xml
+++ b/app/src/main/res/drawable/baseline_pause_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
+    
+</vector>


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #  148 Switch FAB button's icon while Text-to-Speech is playing

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 
To switch the icon of floating action button
### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 
Reviewer can verify the functionality by clicking on the floating action button (pause icon will be displayed)
### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new pause icon for clearer audio playback indication.
- **Refactor**
  - Enhanced the audio control button to dynamically reflect the current playback status.
  - Adjusted button behavior to streamline interactions during audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->