### PR TITLE
chore: ignore kotlin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ lint/tmp/
 # lint/reports/
 
 .DS_Store
+
+# Kotlin
+.kotlin/


### PR DESCRIPTION
Ignore files like `\.kotlin\sessions\kotlin-compiler-12798413355047915190.salive`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version control configuration to exclude Kotlin-related files.
  - Improved formatting for a cleaner setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->