### PR TITLE
Reset TTS FAB icon when leaving chapter/app

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
@@ -290,11 +290,12 @@ open class ChapterFragment : Fragment(), AudioListener {
 
             override fun onStop(utteranceId: String, interrupted: Boolean) {
                 super.onStop(utteranceId, interrupted)
-                Log.v(TAG, "Chapter onStop")
+                Log.v(TAG, "Chapter onStop utteranceId: $utteranceId")
                 if (highlightedTextView != null) {
                     highlightedTextView!!.background =
                         ContextCompat.getDrawable(context!!, R.drawable.bg_word_selector)
                 }
+                fabSpeak?.setImageResource(R.drawable.ic_hearing)
             }
 
             fun scrollToWordIfNotVisible(position: Int) {


### PR DESCRIPTION
* Resolves #148 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved audio interaction feedback: When speech stops, the speak button now updates its icon to clearly indicate the change in state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->