### PR TITLE
bug: Incorrect word click listener when scrolling up/down paragraph(s)

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/WordViewAdapter.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/WordViewAdapter.kt
@@ -50,6 +50,8 @@ internal class WordViewAdapter(
                         words[position], v, position
                     )
                 }
+            } else {
+                holder.itemView.setOnClickListener(null)
             }
         }
     }


### PR DESCRIPTION
bug: Incorrect word click listener when scrolling up/down paragraph(s).

### Issue Number
* Resolves #163 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unintended interactions on list items lacking valid content, ensuring a smoother and more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->