### PR TITLE
fix: re-introduce the fab reset fix

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
@@ -288,11 +288,12 @@ open class ChapterFragment : Fragment(), AudioListener {
 
             override fun onStop(utteranceId: String, interrupted: Boolean) {
                 super.onStop(utteranceId, interrupted)
-                Log.v(TAG, "Chapter onStop")
+                Log.v(TAG, "Chapter onStop utteranceId: $utteranceId")
                 if (highlightedTextView != null) {
                     highlightedTextView!!.background =
                         ContextCompat.getDrawable(context!!, R.drawable.bg_word_selector)
                 }
+                fabSpeak?.setImageResource(R.drawable.ic_hearing)
             }
 
             fun scrollToWordIfNotVisible(position: Int) {


### PR DESCRIPTION
Looks like the changes in https://github.com/elimu-ai/vitabu/pull/164/files were unintentionally reverted in https://github.com/elimu-ai/vitabu/pull/165/commits/6f791176010332f0e31e5b31d3e991a4bee7f789, so re-introducing them here.

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* #148

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [x] I tested my changes on Android 15 (API 35)
- [x] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [x] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [x] I tested my changes on Android 8.0 (API 26)

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced audio playback feedback: The speak button now displays a hearing icon when audio stops, providing clearer visual cues during use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->