### PR TITLE
Do not setText for TextView in worker thread

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
@@ -237,9 +237,9 @@ open class ChapterFragment : Fragment(), AudioListener {
 
                 // Highlight the word being spoken
                 if (wordPosition[0] > -1) {
-                    itemView = layoutManager!!.findViewByPosition(wordPosition[0])
-                    if (itemView != null) {
-                        itemView.background =
+                    itemView = layoutManager?.findViewByPosition(wordPosition[0])
+                    CoroutineScope(Dispatchers.Main).launch {
+                        itemView?.background =
                             ContextCompat.getDrawable(context!!, R.drawable.bg_word_selector)
                     }
                 }

--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/CoverFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/CoverFragment.kt
@@ -14,6 +14,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.Collections
 
 class CoverFragment : ChapterFragment() {
@@ -110,7 +113,9 @@ class CoverFragment : ChapterFragment() {
                         end,
                         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
                     )
-                    audioTextView?.text = spannable
+                    CoroutineScope(Dispatchers.Main).launch {
+                        audioTextView?.text = spannable
+                    }
                 }
             }
 


### PR DESCRIPTION
### Issue Number
* Resolves #206 

### Purpose
Do not setText for TextView in worker thread 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [x] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of text highlighting during speech playback to ensure smooth and consistent UI updates.
  - Enhanced UI responsiveness by updating text and background highlights asynchronously during speech narration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->