### PR TITLE
Use getParcelableExtra API from common-utils

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/StoryBookActivity.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/StoryBookActivity.kt
@@ -1,11 +1,11 @@
 package ai.elimu.vitabu.ui.storybook
 
+import ai.elimu.common.utils.getParcelableCompat
 import ai.elimu.content_provider.utils.ContentProviderUtil
 import ai.elimu.model.v2.enums.ReadingLevel
 import ai.elimu.vitabu.BuildConfig
 import ai.elimu.vitabu.R
 import ai.elimu.vitabu.ui.viewpager.ZoomOutPageTransformer
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
@@ -25,11 +25,9 @@ class StoryBookActivity : AppCompatActivity() {
 
         val storyBookId = intent.getLongExtra(EXTRA_KEY_STORYBOOK_ID, 0)
         Log.i(TAG, "storyBookId: $storyBookId")
-        val readingLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(EXTRA_KEY_STORYBOOK_LEVEL, ReadingLevel::class.java)
-        } else {
-            intent.getParcelableExtra(EXTRA_KEY_STORYBOOK_LEVEL)
-        }
+        val readingLevel = intent.extras?.getParcelableCompat(
+            EXTRA_KEY_STORYBOOK_LEVEL, ReadingLevel::class.java
+        )
         val description = intent.getStringExtra(EXTRA_KEY_STORYBOOK_DESCRIPTION) ?: ""
         
         // Fetch StoryBookChapters from the elimu.ai Content Provider (see https://github.com/elimu-ai/content-provider)


### PR DESCRIPTION
Use getParcelableExtra API from `common-utils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified how reading level information is retrieved, improving compatibility across Android versions. No visible changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->