### PR TITLE
Item background is being updated in worker thread in onDone of ChapterFragment

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/ChapterFragment.kt
@@ -268,16 +268,18 @@ open class ChapterFragment : Fragment(), AudioListener {
             override fun onDone(utteranceId: String) {
                 Log.v(TAG, "Chapter onDone. isSpeaking: " + ttsViewModel.isSpeaking() + ". utteranceId: " + utteranceId + "\nchapterParagraphs.size: " + chapterParagraphs.size)
 
-                // Remove highlighting of the last spoken word
-                val itemView = layoutManager!!.findViewByPosition(wordPosition[0])
-                if (itemView != null) {
-                    itemView.background =
-                        ContextCompat.getDrawable(context!!, R.drawable.bg_word_selector)
-                }
+                CoroutineScope(Dispatchers.Main).launch {
+                    // Remove highlighting of the last spoken word
+                    val itemView = layoutManager?.findViewByPosition(wordPosition[0])
+                    context?.let { ctx ->
+                        itemView?.background =
+                            ContextCompat.getDrawable(ctx, R.drawable.bg_word_selector)
+                    }
 
-                val finalUtteranceId = (chapterParagraphs.size - 1).toString()
-                if (utteranceId == finalUtteranceId) {
-                    fabSpeak?.setImageResource(R.drawable.ic_hearing)
+                    val finalUtteranceId = (chapterParagraphs.size - 1).toString()
+                    if (utteranceId == finalUtteranceId) {
+                        fabSpeak?.setImageResource(R.drawable.ic_hearing)
+                    }
                 }
             }
 


### PR DESCRIPTION
### Issue Number
The exception thrown out when item background is updated in worker thread is here: https://github.com/elimu-ai/vitabu/pull/216#pullrequestreview-2779971616


### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 15 (API 35)
- [x] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app stability by ensuring UI updates occur on the main thread when finishing audio playback in storybook chapters.
  - Enhanced app reliability by adding safety checks to prevent potential crashes during UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->