### PR TITLE
Replace `Uri.parse` with `toUri()`

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/util/ImageProviderExt.kt
+++ b/app/src/main/java/ai/elimu/vitabu/util/ImageProviderExt.kt
@@ -3,16 +3,16 @@ package ai.elimu.vitabu.util
 import ai.elimu.vitabu.BuildConfig
 import android.content.ContentUris
 import android.content.Context
-import android.net.Uri
 import android.util.Log
 import androidx.annotation.WorkerThread
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import androidx.core.net.toUri
 
 @WorkerThread
 suspend fun Context.readImageBytes(fileId: Long): ByteArray? {
-    val uri = Uri.parse("content://" + BuildConfig.CONTENT_PROVIDER_APPLICATION_ID
-            + ".provider.image_provider/images/")
+    val uri = ("content://" + BuildConfig.CONTENT_PROVIDER_APPLICATION_ID
+            + ".provider.image_provider/images/").toUri()
 
     val imageUri = ContentUris.withAppendedId(uri, fileId)
 


### PR DESCRIPTION
Replace `Uri.parse` with `toUri()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated how URIs are constructed internally for improved consistency, with no impact on app functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->