### PR TITLE
Use Jetpack Compose in MainActivity instead of XML layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,14 @@
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'dagger.hilt.android.plugin'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'maven-publish'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dagger.hilt.android.plugin'
+    id 'kotlin-kapt'
+    id 'maven-publish'
+    id "org.jetbrains.kotlin.plugin.compose" version "2.1.21"
+}
 
 android {
     compileSdk 35

--- a/app/src/main/java/ai/elimu/vitabu/MainActivity.kt
+++ b/app/src/main/java/ai/elimu/vitabu/MainActivity.kt
@@ -54,13 +54,13 @@ fun VitabuTheme(content: @Composable () -> Unit) {
 
 @Composable
 fun MainScreen(onPackageCheck: (Boolean) -> Unit) {
-    val context = LocalContext.current
+    val context = LocalContext.current.applicationContext
     
     // Empty Box as container - the UI is minimal since this is just a launcher activity
     Box(modifier = Modifier.fillMaxSize()) {
         // Check for required package when the composable is first launched
         LaunchedEffect(key1 = Unit) {
-            val hasPackage = ensurePackageInstalledOrPrompt(
+            val hasPackage = context.ensurePackageInstalledOrPrompt(
                 packageName = BuildConfig.CONTENT_PROVIDER_APPLICATION_ID,
                 launchPackage = BuildConfig.APPSTORE_APPLICATION_ID,
                 launchClass = "ai.elimu.appstore.MainActivity",

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ buildscript {
     }
 }
 
+plugins {
+    // Existing plugins
+    alias(libs.plugins.compose.compiler)
+}
+
 allprojects {
     repositories {
         google()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidXEspresso = "3.6.1"
 kotlinGradlePlugin = "2.1.21"
 kotlinCoroutines = "1.10.2"
 agp = "8.8.2"
+kotlinx-metadata-jvm = "0.6.0"
 
 # Jetpack Compose
 composeUi = "1.5.4"
@@ -32,6 +33,7 @@ kotlin-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutine
 androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXJunit" }
 androidx-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidXEspresso" }
+kotlinx-metadata-jvm = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version.ref = "kotlinx-metadata-jvm" }
 
 # Jetpack Compose
 compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "composeUi" }
@@ -47,3 +49,4 @@ android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", ve
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin"}
 
 [plugins]
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinGradlePlugin" }


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #

### Purpose
Use Jetpack Compose in MainActivity instead of XML layout

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [ ] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Jetpack Compose for building the app’s user interface, replacing the previous XML-based layout in the main screen.
  - The main screen now uses a modern Material3 design and improved theming.
- **Refactor**
  - Updated the main activity to use a Compose-based implementation for UI and logic flow.
- **Chores**
  - Updated build configuration and dependencies to support Jetpack Compose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->