### PR TITLE
Exclude cover page from storybook reading time tracking

### DIFF
--- a/app/src/main/java/ai/elimu/vitabu/ui/storybook/StoryBookActivity.kt
+++ b/app/src/main/java/ai/elimu/vitabu/ui/storybook/StoryBookActivity.kt
@@ -69,14 +69,16 @@ class StoryBookActivity : AppCompatActivity() {
             }
 
             override fun onPageSelected(position: Int) {
-                val timeSpentOnPage = ((SystemClock.elapsedRealtime() - startReadingTime) / 1000).toInt()
+                if (position > 1) {
+                    val timeSpentOnPage = ((SystemClock.elapsedRealtime() - startReadingTime) / 1000).toInt()
 
-                // Check if this page has been read. If it's the first time being read, just record
-                // the time.
-                // Otherwise, if we find a record of time spent on this page, and new time spent is
-                // smaller than recorded one, the page is likely being skipped, so we should ignore it
-                if (timeSpentOnPage > timeSpent.getOrDefault(position, -1)) {
-                    timeSpent[position] = timeSpentOnPage
+                    // Check if this page has been read. If it's the first time being read, just record
+                    // the time.
+                    // Otherwise, if we find a record of time spent on this page, and new time spent is
+                    // smaller than recorded one, the page is likely being skipped, so we should ignore it
+                    if (timeSpentOnPage > timeSpent.getOrDefault(position, -1)) {
+                        timeSpent[position] = timeSpentOnPage
+                    }
                 }
 
                 startReadingTime = SystemClock.elapsedRealtime()


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #292

### Purpose
Exclude cover page from storybook reading time tracking

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)
